### PR TITLE
Update v5.9_PEDSnet_CDM_ETL_Conventions.md

### DIFF
--- a/PEDSnet/docs/Conventions Docs/v5.9_PEDSnet_CDM_ETL_Conventions.md
+++ b/PEDSnet/docs/Conventions Docs/v5.9_PEDSnet_CDM_ETL_Conventions.md
@@ -6,7 +6,7 @@ Version v5.9 of the PEDSnet CDM reflects the ETL processes developed after sever
 
 This document provides the ETL processing assumptions and conventions developed by the PEDSnet data partners that should be used by a data partner for ensuring common ETL business rules. This document will be modified as new situations are identified, incorrect business rules are identified and replaced, as new analytic use cases impose new/different ETL rules, and as the PEDSnet CDM continues to evolve.
 
-Comments on this specification and ETL rules are welcome. Please send email to pedsnetdcc@email.chop.edu, or contact the PEDSnet project management office (details available via http://www.pedsnet.info).
+Comments on this specification and ETL rules are welcome. Please send email to pedsnetdcc@chop.edu, or contact the PEDSnet project management office (details available via [https://pedsnet.org](https://pedsnet.org/contact/)).
 
 #### PEDSnet Data Standards and Interoperability Policies:
  


### PR DESCRIPTION
fix web link - minor change, but in current PEDSnet CDM definition, pointed to non-existent web site